### PR TITLE
Implement Appolo sample code

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "immutable": "^3.8.1",
     "ramda": "^0.24.1",
     "react": "^15.6.1",
+    "react-apollo": "^1.4.14",
     "react-chartjs-2": "^2.6.1",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.5",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,60 +2,50 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import {
-  QueryRenderer,
+  ApolloClient,
+  createNetworkInterface,
+  ApolloProvider,
+  gql,
   graphql,
-} from 'react-relay';
-import {
-  Environment,
-  Network,
-  RecordSource,
-  Store,
-} from 'relay-runtime';
+} from 'react-apollo';
 
 import List from './List';
 
 const mountNode = document.getElementById('root');
 
-function fetchQuery(
-  operation,
-  variables,
-) {
-  return fetch('https://api.github.com/graphql', {
-    method: 'POST',
+const networkInterface = createNetworkInterface({
+  uri: 'https://api.github.com/graphql',
+  opts: {
     headers: {
       'Content-Type': 'application/json',
-      'Authorization: bearer': process.env.TOKEN
+      'Authorization': `bearer ${process.env.TOKEN}`,
     },
-    body: JSON.stringify({
-      query: operation.text,
-      variables,
-    }),
-  }).then(response => {
-    return response.json();
-  });
-}
+  },
+})
 
-const modernEnvironment = new Environment({
-  network: Network.create(fetchQuery),
-  store: new Store(new RecordSource()),
+const client = new ApolloClient({
+  networkInterface: networkInterface,
 });
 
+const listQuery = gql`
+query {
+  viewer {
+    gists(first: 1) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+}
+`;
+
+const ListWithData = graphql(listQuery)(List);
+
 ReactDOM.render(
-  <QueryRenderer
-    environment={modernEnvironment}
-    query={graphql`
-      query AppQuery {
-        gists
-      }
-    `}
-    variables={{}}
-    render={({error, props}) => {
-      if (props) {
-        return <List viewer={props.viewer} />;
-      } else {
-        return <div>Loading</div>;
-      }
-    }}
-  />,
+  <ApolloProvider client={client}>
+    <ListWithData />
+  </ApolloProvider>,
   mountNode
 );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,51 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import {
-  ApolloClient,
-  createNetworkInterface,
-  ApolloProvider,
-  gql,
-  graphql,
-} from 'react-apollo';
-
 import List from './List';
 
 const mountNode = document.getElementById('root');
 
-const networkInterface = createNetworkInterface({
-  uri: 'https://api.github.com/graphql',
-  opts: {
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `bearer ${process.env.TOKEN}`,
-    },
-  },
-})
-
-const client = new ApolloClient({
-  networkInterface: networkInterface,
-});
-
-const listQuery = gql`
-query {
-  viewer {
-    gists(first: 1) {
-      edges {
-        node {
-          id
-        }
-      }
-    }
-  }
-}
-`;
-
-const ListWithData = graphql(listQuery)(List);
-
 ReactDOM.render(
-  <ApolloProvider client={client}>
-    <ListWithData />
-  </ApolloProvider>,
+  <List />,
   mountNode
 );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,10 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import List from './List';
+import MutateComponent from './Comment'
 
 const mountNode = document.getElementById('root');
 
 ReactDOM.render(
-  <List />,
+  <div>
+    <List />
+    <MutateComponent />
+  </div>,
   mountNode
 );

--- a/src/Comment.jsx
+++ b/src/Comment.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {
+  ApolloClient,
+  createNetworkInterface,
+  ApolloProvider,
+  gql,
+  graphql,
+} from 'react-apollo';
+
+const networkInterface = createNetworkInterface({
+  uri: 'https://api.github.com/graphql',
+  opts: {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `bearer ${process.env.TOKEN}`,
+    },
+  },
+})
+
+const client = new ApolloClient({
+  networkInterface: networkInterface,
+});
+
+const addCommentQuery = gql`
+mutation addComment {
+  addComment(input: { body: "test comment with Apollo!", subjectId: "MDExOlB1bGxSZXF1ZXN0MTM3MzkyMzg5"}) {
+    clientMutationId
+  }
+}
+`;
+
+const dummyItem = ({ mutate }) => {
+  mutate()
+  return null
+}
+
+const Mutate = graphql(addCommentQuery)(dummyItem);
+
+class MutateComponent extends React.Component {
+  render() {
+    return (
+      <ApolloProvider client={client}>
+        <Mutate />
+      </ApolloProvider>
+    )
+  }
+}
+
+export default MutateComponent;

--- a/src/List.jsx
+++ b/src/List.jsx
@@ -1,9 +1,60 @@
 import React from 'react';
+import {
+  ApolloClient,
+  createNetworkInterface,
+  ApolloProvider,
+  gql,
+  graphql,
+} from 'react-apollo';
 
-export default ({ data: { viewer } }) => {
-  if (viewer) {
-    return <div>{viewer.gists.edges[0].node.id}</div>;
+const networkInterface = createNetworkInterface({
+  uri: 'https://api.github.com/graphql',
+  opts: {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `bearer ${process.env.TOKEN}`,
+    },
+  },
+})
+
+const client = new ApolloClient({
+  networkInterface: networkInterface,
+});
+
+const listQuery = gql`
+query {
+  viewer {
+    gists(first: 1) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
   }
-
-  return <div>loading...</div>;
 }
+`;
+
+const ListItem = ({ data: { viewer, loading, error } }) => {
+    if (loading) {
+      return <div>loading...</div>;
+    }
+    if (error) {
+      return <div>error!</div>;
+    }
+    return <div>{viewer.gists.edges[0].node.id}</div>;
+}
+
+const ListItemWithData = graphql(listQuery)(ListItem);
+
+class List extends React.Component {
+  render() {
+    return (
+      <ApolloProvider client={client}>
+        <ListItemWithData />
+      </ApolloProvider>
+    )
+  }
+}
+
+export default List;

--- a/src/List.jsx
+++ b/src/List.jsx
@@ -1,1 +1,9 @@
-export default () => <div>Hello!</div>
+import React from 'react';
+
+export default ({ data: { viewer } }) => {
+  if (viewer) {
+    return <div>{viewer.gists.edges[0].node.id}</div>;
+  }
+
+  return <div>loading...</div>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/graphql@0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.10.2.tgz#d7c79acbaa17453b6681c80c34b38fcb10c4c08c"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -77,6 +81,28 @@ anymatch@^1.3.0:
   dependencies:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
+
+apollo-client@^1.4.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-1.9.1.tgz#9e6a383605572c755038cf5d7fdac9382bcdc040"
+  dependencies:
+    apollo-link-core "^0.5.0"
+    graphql "^0.10.0"
+    graphql-anywhere "^3.0.1"
+    graphql-tag "^2.0.0"
+    redux "^3.4.0"
+    symbol-observable "^1.0.2"
+    whatwg-fetch "^2.0.0"
+  optionalDependencies:
+    "@types/graphql" "0.10.2"
+
+apollo-link-core@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/apollo-link-core/-/apollo-link-core-0.5.0.tgz#dc87da1aaa63b029321ae70938dc26257f5ab8c6"
+  dependencies:
+    graphql "^0.10.3"
+    graphql-tag "^2.4.2"
+    zen-observable-ts "^0.4.0"
 
 aproba@^1.0.3:
   version "1.1.2"
@@ -2129,11 +2155,19 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graphql-anywhere@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-3.1.0.tgz#3ea0d8e8646b5cee68035016a9a7557c15c21e96"
+
 graphql-relay@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.2.tgz#40ff714efd60c2cd89e0bcc79e2afa6d87fa8673"
 
-graphql@^0.10.5:
+graphql-tag@^2.0.0, graphql-tag@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.4.2.tgz#6a63297d8522d03a2b72d26f1b239aab343840cd"
+
+graphql@^0.10.0, graphql@^0.10.3, graphql@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
   dependencies:
@@ -2229,7 +2263,7 @@ hoist-non-react-statics@^1.0.0, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.2.1:
+hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.0.tgz#ede16318c2ff1f9fe3a025396ba06fd4c44608bb"
 
@@ -2349,7 +2383,7 @@ interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -2800,6 +2834,10 @@ lodash.merge@^3.3.2:
     lodash.keys "^3.0.0"
     lodash.keysin "^3.0.0"
     lodash.toplainobject "^3.0.0"
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
 
 lodash.restparam@^3.0.0:
   version "3.6.1"
@@ -3536,6 +3574,18 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-apollo@^1.4.14:
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-1.4.14.tgz#86af913887e447710e4e5d85ca6277b35f1a3b82"
+  dependencies:
+    apollo-client "^1.4.0"
+    graphql-tag "^2.0.0"
+    hoist-non-react-statics "^2.2.0"
+    invariant "^2.2.1"
+    lodash.pick "^4.4.0"
+    object-assign "^4.0.1"
+    prop-types "^15.5.8"
+
 react-chartjs-2@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-2.6.1.tgz#d6499780f5dcac934b5c293e68d9650c98145873"
@@ -3662,7 +3712,7 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux@^3.7.2:
+redux@^3.4.0, redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
   dependencies:
@@ -4241,7 +4291,7 @@ supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-symbol-observable@^1.0.3, symbol-observable@^1.0.4:
+symbol-observable@^1.0.2, symbol-observable@^1.0.3, symbol-observable@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
@@ -4611,7 +4661,7 @@ websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
@@ -4746,3 +4796,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+zen-observable-ts@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.4.0.tgz#a74bc9fe59747948a577bd513d438e70fcfae7e2"


### PR DESCRIPTION
React-Apollo を使って Github gist から1件 id を取得して表示するサンプル。
参考にしたのは以下のページ。

https://github.com/apollographql/react-apollo
http://qiita.com/bananaumai/items/2cd6d48df20b378a44f5
https://developer.github.com/v4/


### やること

- [x] query で何かデータを取ってくるサンプルの作成
    - github gist の適当な id を1件取ってくるとか
- [x] mutate で何かデータを追加するサンプルの作成
    - github gist を 1件追加するとか
    - このPRのコメントを1件追加するとか


### 動作確認

環境変数に TOKEN という名前で github のパーソナルアクセストークンをセットする必要があります。

なにはともあれ `yarn install`.
yarn が無い場合は `npm install -g yarn` してから。

その後 `yarn run start` でサーバが立ち上がるので、 http://localhost:8080/ にアクセス。
なんらかのランダムな文字列（gistのid）が表示されていればOKです。


### 気になったこと

- 元PRで使われているクエリとだいぶ違うクエリ文字列を使用している
    - query 直下で gist が指定できなかったが、これは Apollo と Relay の違い…？